### PR TITLE
Mocha+Chai for tests

### DIFF
--- a/node/mo/package.json
+++ b/node/mo/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "mocha 'out/**/*.test.js'"
   },
   "dependencies": {
     "bulma": "^0.9.4",
@@ -18,12 +19,16 @@
     "validator": "^13.7.0"
   },
   "devDependencies": {
+    "@types/chai": "^4.3.3",
+    "@types/mocha": "^9.1.1",
     "@types/node": "18.7.18",
     "@types/react": "18.0.20",
     "@types/react-dom": "18.0.6",
     "@types/validator": "^13.7.6",
+    "chai": "^4.3.6",
     "eslint": "8.23.1",
     "eslint-config-next": "12.3.0",
+    "mocha": "^10.0.0",
     "typescript": "4.8.3"
   }
 }

--- a/node/mo/tsconfig.json
+++ b/node/mo/tsconfig.json
@@ -1,20 +1,32 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "outDir": "out",
+    "sourceMap": true,
+    "noEmit": false
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/node/mo/utils/db.test.ts
+++ b/node/mo/utils/db.test.ts
@@ -1,0 +1,8 @@
+import { suite, test } from 'mocha';
+import { expect } from 'chai';
+
+suite('Basic tests', async () => {
+    test('Some math', async () => {
+        expect(2 + 2).to.eql(4);
+    });
+});


### PR DESCRIPTION
This adds Mocha (test framework) and Chai (assertion library) to write simple tests for non-UI components.