### PR TITLE
Use port 80 by default to enable mo->127.0.0.1 redirects in /etc/hosts

### DIFF
--- a/node/mo/README.md
+++ b/node/mo/README.md
@@ -16,7 +16,7 @@ Add a local environment settings file: `.env.local`
 
 ```
 DATABASE_URL=mongodb://localhost:27017/mo_links
-API_URL=http://localhost:3000/api/links
+API_URL=http://localhost:80/api/links
 ```
 
 You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.

--- a/node/mo/package.json
+++ b/node/mo/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 80",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 80",
     "lint": "next lint",
     "test": "mocha 'out/**/*.test.js'"
   },


### PR DESCRIPTION
Here's my etc hosts:
```
$ cat /etc/hosts
##
# Host Database
#
# localhost is used to configure the loopback interface
# when the system is booting.  Do not change this entry.
##
127.0.0.1       localhost
255.255.255.255 broadcasthost
::1             localhost
127.0.0.1       mo
```

You'll also need to update the port of API_URL in .env.local