### PR TITLE
Fix API resolved without sending a response for /api/links, this may result in stalled requests

### DIFF
--- a/node/mo/pages/api/links/[id].ts
+++ b/node/mo/pages/api/links/[id].ts
@@ -41,7 +41,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
     // Check if there is a response for the particular method, if so invoke it, if not response with an error
     const response = handleCase[method]
-    if (response) response(req, res)
+    if (response) await response(req, res)
     else res.status(400).json({ error: "No Response for This Request" })
 }
 

--- a/node/mo/pages/api/links/index.ts
+++ b/node/mo/pages/api/links/index.ts
@@ -25,7 +25,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
     // Check if there is a response for the particular method, if so invoke it, if not response with an error
     const response = handleCase[method]
-    if (response) response(req, res)
+    if (response) await response(req, res)
     else res.status(400).json({ error: "No Response for This Request" })
 }
 


### PR DESCRIPTION
Fixes these warnings:
```
API resolved without sending a response for /api/links, this may result in stalled requests.
...
API resolved without sending a response for /api/links/hello_world, this may result in stalled requests.
```
