### PR TITLE
A Primitive DB Wrapping API

### DIFF
--- a/node/mo/package.json
+++ b/node/mo/package.json
@@ -30,5 +30,8 @@
     "eslint-config-next": "12.3.0",
     "mocha": "^10.0.0",
     "typescript": "4.8.3"
+  },
+  "mocha": {
+    "spec": "out/**/*.test.js"
   }
 }

--- a/node/mo/utils/db.test.ts
+++ b/node/mo/utils/db.test.ts
@@ -1,8 +1,62 @@
-import { suite, test } from 'mocha';
+import { MongoClient, Db } from "mongodb";
+
+import { suite, test, Context, suiteSetup, setup, suiteTeardown, teardown } from 'mocha';
 import { expect } from 'chai';
 
-suite('Basic tests', async () => {
-    test('Some math', async () => {
-        expect(2 + 2).to.eql(4);
+import * as dbmod from "./db";
+
+function _requireDatabaseURL(ctx: Context) {
+  // The DATABASE_URL is used to open a client in newMongoClient()
+  if (!('DATABASE_URL' in process.env)) {
+    ctx.skip();
+  }
+}
+
+/**
+ * These tests don't do much interesting, just exercising the driver and the simple wrapping APIs
+ */
+suite('With a client', function () {
+  // Check that we have a DATABASE_URL set, or skip the tests
+  this.beforeAll('Require databases', function () { _requireDatabaseURL(this); });
+
+  let cl: MongoClient;
+  suiteSetup('Open a client', async () => {
+    cl = await dbmod.newMongoClient();
+  });
+  suiteTeardown('Close a client', async () => {
+    if (cl) await cl.close();
+  });
+
+  suite('With a database', () => {
+    let db: Db;
+    setup('Create database', () => {
+      db = cl.db('test-molinks');
     });
+    teardown('Cleanup the database', async () => {
+      if (db) await db.dropDatabase();
+    });
+
+    test('Create the default collection', async () => {
+      const coll = await dbmod.openCollection<dbmod.LinkDocument>('default', db);
+      // Default is empty
+      const cursor = coll.find();
+      const doc = await cursor.next();
+      expect(doc, 'expect empty collection').to.be.null;
+    });
+
+    test('Insert a link', async () => {
+      const coll = await dbmod.openCollection<dbmod.LinkDocument>('links', db);
+      const result = await coll.insertOne({
+        alias: 'widgets',
+        link: 'gadgets',
+        n: 1,
+      });
+      expect(result.acknowledged).to.be.true;
+      const recover = await coll.findOne({ _id: result.insertedId });
+      expect(recover).to.not.be.null;
+      expect(recover?.alias).to.eql('widgets');
+      expect(recover?._id.id).to.eql(result.insertedId.id);
+      expect(recover?.n).to.eq(1);
+    });
+  });
 });

--- a/node/mo/utils/db.ts
+++ b/node/mo/utils/db.ts
@@ -1,0 +1,86 @@
+import { MongoClient, Collection, Db, Document } from "mongodb";
+import { MOLINKS_CONFIG } from "./config";
+
+/**
+ * @returns A new MongoClient connected with the default database URL.
+ *
+ * @note This will need to be closed!
+ */
+export async function newMongoClient(): Promise<MongoClient> {
+    return MongoClient.connect(MOLINKS_CONFIG.DATABASE_URL, {
+        appName: 'molinks',
+        connectTimeoutMS: 1_000,
+    });
+}
+
+/**
+ * Perform work with a new MongoClient, automatically closing it when the handler exits
+ *
+ * @param fn A handler that performs work with the given MongoClient
+ * @returns The return value from the callback
+ */
+export async function withClient<T>(fn: (client: MongoClient) => T): Promise<Awaited<T>> {
+    const client = await newMongoClient();
+    try {
+        return await fn(client);
+    } finally {
+        await client.close();
+    }
+}
+
+/**
+ * @param client An optional client to use
+ * @returns {Db} An open
+ */
+export async function openDefaultDB(client: MongoClient): Promise<Db> {
+    return client.db('molinks');
+}
+
+/**
+ * The type of document that contains aliased links
+ */
+export interface LinkDocument {
+    /// The spelling of the alias of the link
+    alias: string;
+    /// The target of the link
+    link: string;
+    /// The number of times the link has been used
+    n: number;
+}
+
+/**
+ * @param name The name of the collection to open
+ * @returns A new handle to the collection
+ */
+export async function openCollection<T extends Document>(name: string, db: Db): Promise<Collection<T>>;
+export async function openCollection<T extends Document>(name: string, client: MongoClient): Promise<Collection<T>>;
+export async function openCollection<T extends Document>(name: string, dbOrClient: Db | MongoClient): Promise<Collection<T>> {
+    if (dbOrClient instanceof MongoClient) {
+        dbOrClient = await openDefaultDB(dbOrClient);
+    }
+    return dbOrClient.collection<T>(name);
+}
+
+/**
+ * Opne the LinkDocument collection in the database
+ *
+ * @param db Override the database to connect to
+ * @returns A handle to the collection of LinkDocument objects
+ */
+export async function openLinksCollection(db: Db): Promise<Collection<LinkDocument>> {
+    return openCollection<LinkDocument>('links', db);
+}
+
+
+/**
+ * Invoke a handler that works with a set of links, closing the client when finished.
+ * @param fn The handler that works with the links data
+ * @returns A promise that returns the result of the handler
+ */
+export async function withLinksCollection<T>(fn: (links: Collection<LinkDocument>) => T): Promise<Awaited<T>> {
+    return await withClient(async (client) => {
+        const db = await openDefaultDB(client);
+        const coll = await openLinksCollection(db);
+        return await fn(coll);
+    });
+}


### PR DESCRIPTION
This defines a very rudimentary set of convenience functions that wrap the bare driver API with some "reasonable defaults" for the application. From here, more interfaces can be defined, and we can interact with the driver API directly.