### PR TITLE
Improve matching logic

### DIFF
--- a/node/mo/pages/api/links/index.ts
+++ b/node/mo/pages/api/links/index.ts
@@ -22,6 +22,7 @@ export default createMethodHandler({
     const dbDoc = {
       alias: doc.alias,
       link: doc.link,
+      isRegex: doc.isRegex || false,
       createdAt: new Date(),
       n: 0,
     }

--- a/node/mo/pages/index.tsx
+++ b/node/mo/pages/index.tsx
@@ -29,6 +29,7 @@ function rowFromData(item: ExtendedJSONEncoded<WithId<MoLink>>) {
   return (
     <tr key={link._id.toString()}>
       <td>{link.alias}</td>
+      <td>{link.isRegex ? "✔" : "✗"}</td>
       <td><a href={link.link}>{link.link}</a></td>
       <td>{link.n || 0}</td>
       <td>{dateString}</td>
@@ -54,6 +55,7 @@ function Index(props: IndexProps) {
             <thead>
               <tr>
                 <th>Alias</th>
+                <th>Is Regex</th>
                 <th>Link</th>
                 <th>Count</th>
                 <th>Created</th>

--- a/node/mo/pages/links/[id].tsx
+++ b/node/mo/pages/links/[id].tsx
@@ -68,6 +68,12 @@ function EditForm(props: Props) {
             </div>
           </div>
           <div className="field">
+            <label className="checkbox">
+              Is Regex redirect: &nbsp;
+              <input className="checkbox" type="checkbox" name="isRegex" value="true" checked={values.isRegex} onChange={handleChange} />
+            </label>
+          </div>
+          <div className="field">
             <label className="label">Link</label>
             <div className="control">
               <input className="input is-link" type="text" name="link" value={values?.link} onChange={handleChange} />

--- a/node/mo/utils/types.ts
+++ b/node/mo/utils/types.ts
@@ -21,6 +21,8 @@ export interface MoLink {
     n: number;
     /// The time at which this object was created
     createdAt: Date;
+    // is a Regex redirect
+    isRegex: boolean;
 }
 
 /// Type of the data object sent to insert/update a link


### PR DESCRIPTION
A few changes:

- Added isRegex field to the model / forms
- Ensure only matches against links that regex links as alias matching was being too greedy.
- Simplified the redirection, just returning redirect from getServerSideProps is enough
- Auto suggest creating a new alias if none found.