### PR TITLE
Fix npm run build errors

### DIFF
--- a/node/mo/pages/index.tsx
+++ b/node/mo/pages/index.tsx
@@ -18,20 +18,20 @@ function deleteAlias(alias: string) {
   window.location.reload();
 }
 
-function rowFromData(item: ExtendedJSONEncoded<WithId<MoLink>>) {
-  const link = decodedExtendedJSON(item);
-
-  const dateFormat = new Intl.DateTimeFormat(undefined, {
+const dateFormat = new Intl.DateTimeFormat(undefined, {
     dateStyle: 'medium',
     timeStyle: 'medium',
-  });
+});
+
+export function useRowFromData(item: ExtendedJSONEncoded<WithId<MoLink>>) {
+  const link = decodedExtendedJSON(item);
 
   const [dateString, setDateString] = useState('');
   useEffect(() => setDateString(
     link.createdAt
       ? dateFormat.format(new Date(link.createdAt))
       : '[no date recorded]'
-  ));
+  ), [link.createdAt]);
   const editPath = encodeURIComponent(link.alias);
   return (
     <tr key={link._id.toString()}>
@@ -71,7 +71,7 @@ function Index(props: IndexProps) {
               </tr>
             </thead>
             <tbody>
-              {links.map(rowFromData)}
+              {links.map(useRowFromData)}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
Fixes these errors:
```
$ npm run build                           

> mo@0.1.0 build
> next build


Failed to compile.

./pages/index.tsx
29:39  Error: React Hook "useState" is called in function "rowFromData" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".  react-hooks/rules-of-hooks
30:3  Warning: React Hook useEffect contains a call to 'setDateString'. Without a list of dependencies, this can lead to an infinite chain of updates. To fix this, pass [link.createdAt, dateFormat] as a second argument to the useEffect Hook.  react-hooks/exhaustive-deps
30:3  Error: React Hook "useEffect" is called in function "rowFromData" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".  react-hooks/rules-of-hooks
...
```